### PR TITLE
Make compatible with CompCert 3.9

### DIFF
--- a/vcfloat/cverif/ClightFacts.v
+++ b/vcfloat/cverif/ClightFacts.v
@@ -196,10 +196,9 @@ Proof.
 Qed.
 
 Definition calling_convention_eqb s1 s2 :=
-  andb (Bool.eqb (AST.cc_vararg s1) (AST.cc_vararg s2))
+  andb (option_eqb Z.eqb (AST.cc_vararg s1) (AST.cc_vararg s2))
        (andb (Bool.eqb (AST.cc_unproto s1) (AST.cc_unproto s2))
-            (Bool.eqb (AST.cc_structret s1) (AST.cc_structret s2)))
-.
+            (Bool.eqb (AST.cc_structret s1) (AST.cc_structret s2))).
 
 Lemma calling_convention_eqb_eq s1 s2:
   calling_convention_eqb s1 s2 = true <-> s1 = s2.
@@ -207,6 +206,7 @@ Proof.
   unfold calling_convention_eqb.
   destruct s1; destruct s2; simpl.
   repeat rewrite Bool.andb_true_iff.
+  rewrite (option_eqb_eq (Z.eqb_eq)).
   repeat rewrite Bool.eqb_true_iff.
   intuition congruence.
 Qed.


### PR DESCRIPTION
Between CompCert 3.8 and CompCert 3.9, the type of the `AST.vararg` attribute changed from `bool` to `option Z`.   This brings vcfloat up to date.